### PR TITLE
Add a dockerfile for ALLSorts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.8
+
+ENV PATH "/opt:$PATH"
+
+COPY env/requirements.txt /opt/requirements.txt
+RUN pip install -r /opt/requirements.txt
+
+# install MoRP
+RUN pip install git+https://github.com/breons/MoRP.git
+COPY . /opt/
+RUN pip install -e /opt/

--- a/env/requirements.txt
+++ b/env/requirements.txt
@@ -1,0 +1,7 @@
+joblib==0.15.1
+matplotlib==3.2.1
+numpy==1.18.1
+pandas==1.0.3
+scikit-learn==0.22.1
+scipy==1.4.1
+umap-learn==0.4.4


### PR DESCRIPTION
Can be run like:

```bash
docker build -t oshlack/allsorts:dev .
docker run -it --entrypoint /bin/bash oshlack/allsorts:dev

# inside container
cd /opt/
python ALLSorts -h
```

See (#3) for changes to setup.py to allow for just `ALLSorts`.