### PR TITLE
Add changes to setup.py for local python install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.8
+
+ENV PATH "/opt:$PATH"
+
+COPY env/requirements.txt /opt/requirements.txt
+RUN pip install -r /opt/requirements.txt
+
+# install MoRP
+RUN pip install git+https://github.com/breons/MoRP.git
+COPY . /opt/
+RUN pip install -e /opt/

--- a/env/requirements.txt
+++ b/env/requirements.txt
@@ -1,0 +1,7 @@
+joblib==0.15.1
+matplotlib==3.2.1
+numpy==1.18.1
+pandas==1.0.3
+scikit-learn==0.22.1
+scipy==1.4.1
+umap-learn==0.4.4

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,30 @@
 # Setup Python module
-from setuptools import setup
+from setuptools import setup, find_packages
 
-setup(name='ALLSorts',
-      version='0.1',
-      description='BALL Subtype Classifier/Investigator.',
-      url='https://github.com/breons/ALLSorts',
-      author='Breon Schmidt',
-      license='MIT',
-      packages=['ALLSorts'],
-      zip_safe=False)
+modules = ["ALLSorts." + p for p in sorted(find_packages("./ALLSorts"))]
+
+setup(
+    name="ALLSorts",
+    version="0.1",
+    description="BALL Subtype Classifier/Investigator.",
+    url="https://github.com/breons/ALLSorts",
+    author="Breon Schmidt",
+    license="MIT",
+    packages=["ALLSorts", *modules],
+    zip_safe=False,
+    install_requires=[
+        "joblib==0.15.1",
+        "matplotlib==3.2.1",
+        "numpy==1.18.1",
+        "pandas==1.0.3",
+        "scikit-learn==0.22.1",
+        "scipy==1.4.1",
+        "umap-learn==0.4.4",
+    ],
+    entry_points={
+          "console_scripts": ["ALLSorts=ALLSorts.allsorts:run"]
+    },
+#     package_data={
+#           "models": ["*"]
+#     }
+)


### PR DESCRIPTION
Goal: to run ALLSorts with just:

```bash
ALLSorts -h
```

With this change, you could easily deploy to PyPI, and then you could install with:

```bash
pip install ALLSorts
```

Still to action:
- Including static assets (pre trained models + csvs)
- Retrain the model to allow Pickle to understand revised module structure (`ALLSorts.pipeline` instead of just `pipeline`)