### PR TITLE
Pin numba

### DIFF
--- a/env/allsorts.yml
+++ b/env/allsorts.yml
@@ -16,3 +16,4 @@ dependencies:
   - setuptools=46.4.0
   - umap-learn=0.4.4
   - plotly==4.14.3
+  - numba==0.52.0


### PR DESCRIPTION
Experienced same issue as #11 on python 3.8.3 fresh conda install when running tests:

```
numba.core.errors.LoweringError: Failed in nopython mode pipeline (step: nopython mode backend)                                                                                             
Storing i64 to ptr of i32 ('dim'). FE type int32  
```

Reverting `numba` to `0.52.0` seems to fix. `env.yaml` updated accordingly. 