### PR TITLE
add pandas missing dependency to `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(
         "scikit-learn==0.22.1",
         "umap-learn==0.4.4",
         "plotly==4.14.3",
-        "kaleido==0.1.0"
+        "kaleido==0.1.0",
+        "pandas==1.0.3"
     ],
     entry_points={
           "console_scripts": ["ALLSorts=ALLSorts.allsorts:run"]


### PR DESCRIPTION
## Problem
`Pandas==1.0.3` dependency is missing in `setup.py`, causing it to fail when installing it with `pip`.
https://github.com/Oshlack/ALLSorts/blob/be43d6c7dd9d15025f2ba37b9262db44ae4410b7/setup.py#L16-L23

Notice `pandas` is correctly defined in the conda environment file:
https://github.com/Oshlack/ALLSorts/blob/be43d6c7dd9d15025f2ba37b9262db44ae4410b7/env/allsorts.yml#L7-L19

## Replicate error

```bash
$ pip install git+https://github.com/Oshlack/ALLSorts@be43d6c#egg=ALLSorts
$ ALLSorts --help
Traceback (most recent call last):
  File "/tmp/allsorts_virtualenv/bin/ALLSorts", line 5, in <module>
    from ALLSorts.allsorts import run
  File "/tmp/allsorts_virtualenv/lib/python3.6/site-packages/ALLSorts/allsorts.py", line 27, in <module>
    import pandas as pd
ModuleNotFoundError: No module named 'pandas'
```